### PR TITLE
Catppuccin Mocha Blue theme

### DIFF
--- a/themes/catppuccin-mocha-blue/v1/code-block.css
+++ b/themes/catppuccin-mocha-blue/v1/code-block.css
@@ -20,6 +20,7 @@
  */
 
 /* COLOURS: */
+/*
 :root {
     --rosewater: #f5e0dc;
     --flamingo: #f2cdcd;
@@ -48,12 +49,13 @@
     --mantle: #181825;
     --crust: #11111b;
 }
+*/
 
 /* Set the main properties of the code, code blocks, and inline code */
 code[class*="language-"],
 pre[class*="language-"] {
-	background: var(--crust);
-	color: var(--text);
+	background: #11111b;
+	color: #cdd6f4;
 	font-family: "JetBrainsMonoNL Nerd Font", monospace; /* this is the default */
 	/* The following properties are standard, please leave them as they are */
 	font-size: 1em;
@@ -79,14 +81,14 @@ code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection,
 pre[class*="language-"]::-moz-selection,
 pre[class*="language-"] ::-moz-selection {
-	background: rgba(var(--surface2), 0.6);
+	background: rgba(88, 91, 112, 0.6);
 }
 
 code[class*="language-"]::selection,
 code[class*="language-"] ::selection,
 pre[class*="language-"]::selection,
 pre[class*="language-"] ::selection {
-	background: rgba(var(--surface2), 0.6);
+	background: rgba(88, 91, 112, 0.6);
 }
 
 /* Properties specific to code blocks */
@@ -109,23 +111,23 @@ pre[class*="language-"] {
  * The concepts behind these standard tokens, as well as some examples, can be found here: https://prismjs.com/tokens.html
  */
 .token.comment {
-	color: var(--overlay0);
+	color: #6c7086;
 }
 
 .token.prolog {
-	color: var(--overlay0);
+	color: #6c7086;
 }
 
 .token.cdata {
-	color: var(--overlay0);
+	color: #6c7086;
 }
 
 .token.doctype {
-	color: var(--overlay0);
+	color: #6c7086;
 }
 
 .token.punctuation {
-	color: var(--overlay2);
+	color: #9399b2;
 }
 
 .token.entity {
@@ -133,86 +135,86 @@ pre[class*="language-"] {
 }
 
 .token.attr-name {
-	color: var(--maroon);
+	color: #eba0ac;
 }
 
 .token.class-name {
-	color: var(--yellow);
+	color: #f9e2af;
 }
 
 .token.boolean {
-	color: var(--mauve);
+	color: #cba6f7;
 }
 
 .token.constant,
 .token.number {
-	color: var(--peach);
+	color: #fab387;
 }
 
 .token.atrule {
-	color: var(--yellow);
+	color: #f9e2af;
 }
 
 .token.keyword,
 .token.tag {
-	color: var(--mauve);
+	color: #cba6f7;
 }
 
 .token.property {
-	color: var(--maroon);
+	color: #eba0ac;
 }
 
 .token.symbol {
-	color: var(--pink);
+	color: #f5c2e7;
 }
 
 .token.deleted {
-    background: rgba(var(--red), 0.2);
+    background: rgba(243, 139, 168, 0.2);
 }
 
 .token.important {
-	color: var(--yellow);
+	color: #f9e2af;
 }
 
 .token.selector {
-	color: var(--blue);
+	color: #89b4fa;
 }
 
 .token.string,
 .token.char {
-	color: var(--green);
+	color: #a6e3a1;
 }
 
 .token.builtin {
-	color: var(--red);
+	color: #f38ba8;
 }
 
 .token.inserted {
-    background: rgba(var(--green), 0.2);
+    background: rgba(166, 227, 161, 0.2);
 }
 
 .token.regex {
-	color: var(--pink);
+	color: #f5c2e7;
 }
 
 .token.attr-value {
-	color: var(--green);
+	color: #a6e3a1;
 }
 
 .token.variable {
-	color: var(--pink);
+	color: #f5c2e7;
 }
 
 .token.operator {
-	color: var(--sky);
+	color: #89dceb;
 }
 
 .token.function {
-	color: var(--blue);
+	color: #89b4fa;
 }
 
 .token.url {
-	color: var(--blue);
+	color: #89b4fa;
 }
 
 /* The following rules are pretty similar across themes, but feel free to adjust them */

--- a/themes/catppuccin-mocha-blue/v1/code-block.css
+++ b/themes/catppuccin-mocha-blue/v1/code-block.css
@@ -1,0 +1,226 @@
+/**
+ * Your theme's name
+ * If this is an adaptation of an existing theme, credit the creator and/or leave a link to it!
+ * Optional: Your name and/or username
+ */
+
+/**
+ * Prism supports IE11, which does not support CSS variables
+ * However, you are encouraged to leave a list of colours you use here
+ * so that when we transition to Prism V2 (and drop support for IE11),
+ * the transition will be a little easier!
+ */
+
+/**
+ * How to use this template:
+ *
+ * This file contains all the boilerplate necessary for a Prism theme along with template rules for you to fill in.
+ *
+ * All properties with the value `unset` are for you to change.
+ * You should fill in all `color` and `background` properties.
+ * If you don't need an `unset` property (e.g. `border-radius`), then feel free to remove it.
+ * You are also free to add more properties that aren't stated, such as `text-shadow`.
+ * If you wish to style the plugins, you may grab their selectors from their respective .css files in the template folder.
+ *
+ * Your finished theme should have all `unset` properties either filled in or removed.
+ */
+
+/* Set the main properties of the code, code blocks, and inline code */
+code[class*="language-"],
+pre[class*="language-"] {
+	background: unset;
+	color: unset;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* this is the default */
+	/* The following properties are standard, please leave them as they are */
+	font-size: 1em;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	line-height: 1.5;
+	/* The default is 4, but you could change it if you really, really want to */
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	/* The following properties are also standard */
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Optional: What the code looks like when highlighted */
+code[class*="language-"]::-moz-selection,
+code[class*="language-"] ::-moz-selection,
+pre[class*="language-"]::-moz-selection,
+pre[class*="language-"] ::-moz-selection {
+	background: unset;
+	color: unset;
+}
+
+code[class*="language-"]::selection,
+code[class*="language-"] ::selection,
+pre[class*="language-"]::selection,
+pre[class*="language-"] ::selection {
+	background: unset;
+	color: unset;
+}
+
+/* Properties specific to code blocks */
+pre[class*="language-"] {
+	padding: 1em; /* this is standard */
+	margin: 0.5em 0; /* this is the default */
+	overflow: auto; /* this is standard */
+	border-radius: unset;
+}
+
+/* Properties specific to inline code */
+:not(pre) > code[class*="language-"] {
+	padding: 0.1em; /* this is the default */
+	border-radius: unset;
+	white-space: normal; /* this is standard */
+}
+
+/**
+ * These are the minimum tokens you must style, you can rearrange them and/or style more tokens as you want
+ * The concepts behind these standard tokens, as well as some examples, can be found here: https://prismjs.com/tokens.html
+ */
+.token.comment {
+	color: unset;
+}
+
+.token.prolog {
+	color: unset;
+}
+
+.token.cdata {
+	color: unset;
+}
+
+.token.doctype {
+	color: unset;
+}
+
+.token.punctuation {
+	color: unset;
+}
+
+.token.entity {
+	color: unset;
+}
+
+.token.attr-name {
+	color: unset;
+}
+
+.token.class-name {
+	color: unset;
+}
+
+.token.boolean {
+	color: unset;
+}
+
+.token.constant {
+	color: unset;
+}
+
+.token.number {
+	color: unset;
+}
+
+.token.atrule {
+	color: unset;
+}
+
+.token.keyword {
+	color: unset;
+}
+
+.token.property {
+	color: unset;
+}
+
+.token.tag {
+	color: unset;
+}
+
+.token.symbol {
+	color: unset;
+}
+
+.token.deleted {
+	color: unset;
+}
+
+.token.important {
+	color: unset;
+}
+
+.token.selector {
+	color: unset;
+}
+
+.token.string {
+	color: unset;
+}
+
+.token.char {
+	color: unset;
+}
+
+.token.builtin {
+	color: unset;
+}
+
+.token.inserted {
+	color: unset;
+}
+
+.token.regex {
+	color: unset;
+}
+
+.token.attr-value {
+	color: unset;
+}
+
+.token.variable {
+	color: unset;
+}
+
+.token.operator {
+	color: unset;
+}
+
+.token.function {
+	color: unset;
+}
+
+.token.url {
+	color: unset;
+}
+
+/* The following rules are pretty similar across themes, but feel free to adjust them */
+.token.bold {
+	font-weight: bold;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+.token.namespace {
+	opacity: 0.7;
+}
+
+/* LANGUAGE-SPECIFIC OVERRIDES */
+/* If you'd like your theme to have overrides for specific languages, here's an example, you can remove it and/or add more overrides */
+.language-css .token.important {
+	color: unset;
+}

--- a/themes/catppuccin-mocha-blue/v1/code-block.css
+++ b/themes/catppuccin-mocha-blue/v1/code-block.css
@@ -52,9 +52,9 @@
 /* Set the main properties of the code, code blocks, and inline code */
 code[class*="language-"],
 pre[class*="language-"] {
-	background: unset;
-	color: unset;
-	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* this is the default */
+	background: var(--crust);
+	color: var(--text);
+	font-family: "JetBrainsMonoNL Nerd Font", monospace; /* this is the default */
 	/* The following properties are standard, please leave them as they are */
 	font-size: 1em;
 	direction: ltr;
@@ -79,16 +79,14 @@ code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection,
 pre[class*="language-"]::-moz-selection,
 pre[class*="language-"] ::-moz-selection {
-	background: unset;
-	color: unset;
+	background: rgba(var(--surface2), 0.6);
 }
 
 code[class*="language-"]::selection,
 code[class*="language-"] ::selection,
 pre[class*="language-"]::selection,
 pre[class*="language-"] ::selection {
-	background: unset;
-	color: unset;
+	background: rgba(var(--surface2), 0.6);
 }
 
 /* Properties specific to code blocks */
@@ -111,23 +109,23 @@ pre[class*="language-"] {
  * The concepts behind these standard tokens, as well as some examples, can be found here: https://prismjs.com/tokens.html
  */
 .token.comment {
-	color: unset;
+	color: var(--overlay0);
 }
 
 .token.prolog {
-	color: unset;
+	color: var(--overlay0);
 }
 
 .token.cdata {
-	color: unset;
+	color: var(--overlay0);
 }
 
 .token.doctype {
-	color: unset;
+	color: var(--overlay0);
 }
 
 .token.punctuation {
-	color: unset;
+	color: var(--overlay2);
 }
 
 .token.entity {
@@ -135,95 +133,86 @@ pre[class*="language-"] {
 }
 
 .token.attr-name {
-	color: unset;
+	color: var(--maroon);
 }
 
 .token.class-name {
-	color: unset;
+	color: var(--yellow);
 }
 
 .token.boolean {
-	color: unset;
+	color: var(--mauve);
 }
 
-.token.constant {
-	color: unset;
-}
-
+.token.constant,
 .token.number {
-	color: unset;
+	color: var(--peach);
 }
 
 .token.atrule {
-	color: unset;
+	color: var(--yellow);
 }
 
-.token.keyword {
-	color: unset;
+.token.keyword,
+.token.tag {
+	color: var(--mauve);
 }
 
 .token.property {
-	color: unset;
-}
-
-.token.tag {
-	color: unset;
+	color: var(--maroon);
 }
 
 .token.symbol {
-	color: unset;
+	color: var(--pink);
 }
 
 .token.deleted {
-	color: unset;
+    background: rgba(var(--red), 0.2);
 }
 
 .token.important {
-	color: unset;
+	color: var(--yellow);
 }
 
 .token.selector {
-	color: unset;
+	color: var(--blue);
 }
 
-.token.string {
-	color: unset;
-}
-
+.token.string,
 .token.char {
-	color: unset;
+	color: var(--green);
 }
 
 .token.builtin {
-	color: unset;
+	color: var(--red);
 }
 
 .token.inserted {
-	color: unset;
+    background: rgba(var(--green), 0.2);
 }
 
 .token.regex {
-	color: unset;
+	color: var(--pink);
 }
 
 .token.attr-value {
-	color: unset;
+	color: var(--green);
 }
 
 .token.variable {
-	color: unset;
+	color: var(--pink);
 }
 
 .token.operator {
-	color: unset;
+	color: var(--sky);
 }
 
 .token.function {
-	color: unset;
+	color: var(--blue);
 }
 
 .token.url {
-	color: unset;
+	color: var(--blue);
 }
 
 /* The following rules are pretty similar across themes, but feel free to adjust them */
@@ -245,6 +234,7 @@ pre[class*="language-"] {
 
 /* LANGUAGE-SPECIFIC OVERRIDES */
 /* If you'd like your theme to have overrides for specific languages, here's an example, you can remove it and/or add more overrides */
-.language-css .token.important {
+/* .language-css .token.important {
 	color: unset;
-}
+} */
+

--- a/themes/catppuccin-mocha-blue/v1/code-block.css
+++ b/themes/catppuccin-mocha-blue/v1/code-block.css
@@ -1,14 +1,8 @@
 /**
- * Your theme's name
+ * Catppuccin Mocha
  * If this is an adaptation of an existing theme, credit the creator and/or leave a link to it!
- * Optional: Your name and/or username
- */
-
-/**
- * Prism supports IE11, which does not support CSS variables
- * However, you are encouraged to leave a list of colours you use here
- * so that when we transition to Prism V2 (and drop support for IE11),
- * the transition will be a little easier!
+ * By @revsuine
+ * Licenced under the GPL v3
  */
 
 /**
@@ -24,6 +18,36 @@
  *
  * Your finished theme should have all `unset` properties either filled in or removed.
  */
+
+/* COLOURS: */
+:root {
+    --rosewater: #f5e0dc;
+    --flamingo: #f2cdcd;
+    --pink: #f5c2e7;
+    --mauve: #cba6f7;
+    --red: #f38ba8;
+    --maroon: #eba0ac;
+    --peach: #fab387;
+    --yellow: #f9e2af;
+    --green: #a6e3a1;
+    --teal: #94e2d5;
+    --sky: #89dceb;
+    --sapphire: #74c7ec;
+    --blue: #89b4fa;
+    --lavender: #b4befe;
+    --text: #cdd6f4;
+    --subtext1: #bac2de;
+    --subtext0: #a6adc8;
+    --overlay2: #9399b2;
+    --overlay1: #7f849c;
+    --overlay0: #6c7086;
+    --surface2: #585b70;
+    --surface1: #45475a;
+    --surface0: #313244;
+    --base: #313244;
+    --mantle: #181825;
+    --crust: #11111b;
+}
 
 /* Set the main properties of the code, code blocks, and inline code */
 code[class*="language-"],

--- a/themes/catppuccin-mocha-blue/v1/theme.json
+++ b/themes/catppuccin-mocha-blue/v1/theme.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetwriters/notesnook-themes/main/schemas/v1.schema.json",
+  "name": "Catppuccin Mocha Blue",
+  "id": "catppuccin-mocha-blue",
+  "version": 1,
+  "license": "GPL-3.0-or-later",
+  "homepage": "https://notesnook.com",
+  "description": "Catppuccin Mocha with a blue highlihgt",
+  "colorScheme": "dark",
+  "compatibilityVersion": 1,
+  "authors": [
+    {
+      "name": "revsuine"
+    }
+  ],
+  "scopes": {
+    "base": {
+      "primary": {
+        "accent": "#89b4fa",
+        "paragraph": "#cdd6f4",
+        "background": "#181825",
+        "border": "#6c7086",
+        "heading": "#cdd6f4",
+        "icon": "#bac2de",
+        "separator": "#6c7086",
+        "placeholder": "#7f849c",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      },
+      "secondary": {
+        "accent": "#89b4fa",
+        "paragraph": "#cdd6f4",
+        "background": "#11111b",
+        "border": "#6c7086",
+        "heading": "#cdd6f4",
+        "icon": "#cdd6f4",
+        "separator": "#6c7086",
+        "placeholder": "#7f849c",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      },
+      "disabled": {
+        "accent": "#89b4fa",
+        "paragraph": "#cdd6f4",
+        "background": "#7f849c",
+        "border": "#6c7086",
+        "heading": "#cdd6f4",
+        "icon": "#cdd6f4",
+        "separator": "#6c7086",
+        "placeholder": "#cdd6f4",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      },
+      "selected": {
+        "accent": "#89b4fa",
+        "paragraph": "#cdd6f4",
+        "background": "#313244",
+        "border": "#89b4fa",
+        "heading": "#cdd6f4",
+        "icon": "#89b4fa",
+        "separator": "#6c7086",
+        "placeholder": "#7f849c",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      },
+      "error": {
+        "accent": "#f38ba8",
+        "paragraph": "#f38ba8",
+        "background": "#1e1e2e",
+        "border": "#6c7086",
+        "heading": "#f38ba8",
+        "icon": "#f38ba8",
+        "separator": "#6c7086",
+        "placeholder": "#f38ba8",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      },
+      "success": {
+        "accent": "#a6e3a1",
+        "paragraph": "#a6e3a1",
+        "background": "#1e1e2e",
+        "border": "#6c7086",
+        "heading": "#a6e3a1",
+        "icon": "#a6e3a1",
+        "separator": "#6c7086",
+        "placeholder": "#7f849c",
+        "hover": "#45475a",
+        "accentForeground": "#11111b",
+        "backdrop": "#11111b99"
+      }
+    },
+    "list": {
+      "selected": {
+        "background": "#313244"
+      }
+    },
+    "editor": {
+      "primary": {
+        "background": "#1e1e2e"
+      }
+    },
+    "navigationMenu": {
+      "primary": {
+        "background": "#11111b"
+      }
+    },
+    "contextMenu": {
+      "primary": {
+        "background": "#585b70"
+      }
+    },
+    "sheet": {
+      "selected": {
+        "paragraph": "#008837"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi there. I would like to add my theme using the [Catppuccin Mocha colour scheme](https://github.com/catppuccin/catppuccin) with a blue highlight. It also contains code block syntax highlighting with a custom prismjs theme.

This branch is a branch that doesn't use CSS variables, as I found the [Notesnook theme builder](https://theme-builder.notesnook.com/) couldn't display syntax highlighting when I was using CSS variables.