### PR TITLE
fix: added transparency on backdrop

### DIFF
--- a/themes/bumble-dark/v1/theme.json
+++ b/themes/bumble-dark/v1/theme.json
@@ -28,7 +28,7 @@
         "placeholder": "#838377",
         "hover": "#312f1c",
         "accentForeground": "#272725",
-        "backdrop": "#100f0f"
+        "backdrop": "#100f0f80"
       },
       "secondary": {
         "accent": "#e5d56c",


### PR DESCRIPTION
This fix the issue #124 where the settings popup didn't have a transparent opacity like the others themes.

To fix it, i simply added the opacity on the primary backdrop, now we can see the app behind the settings popup.
![image](https://github.com/user-attachments/assets/e2ffa7bc-b1de-4eb5-a84f-b7cdf18607f1)
